### PR TITLE
fix: make rustfmt only check the formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Check Formatting
-      run: rustfmt ./src/*
+      run: rustfmt --check ./src/*
 
     - name: Run tests
       run: cargo test


### PR DESCRIPTION
# Context
Previously, we ran rustfmt in the CI, which lead to it actually reformatting the code instead of checking for wrong formats.
Instead we want to run rustfmt --check.